### PR TITLE
Add multi-location Brooklyn Fabric support

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -1,6 +1,6 @@
 brooklyn.catalog:
   id: brooklyn-hyperledger-fabric
-  version: 0.3
+  version: 0.5
 
   publish:
     description: |

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,6 +1,6 @@
 brooklyn.catalog:
   id: brooklyn-hyperledger-fabric
-  version: 0.1.1_SNAPSHOT
+  version: 0.2.0
 
   publish:
     description: |
@@ -10,34 +10,40 @@ brooklyn.catalog:
 
   items:
 
-  - id: hyperledger-fabric-cluster
+  - id: hyperledger-fabric-template
     description: A Hyperledger Fabric cluster of validating peer nodes, a membership services node, and a CLI node
-    name: Hyperledger Fabric Cluster
+    name: Hyperledger Fabric
     iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
     itemType: template
     item:
       services:
-      - type: hyperledger-fabric-cluster-app
+      - type: hyperledger-fabric-cluster
         id: hyperledger-deployment
-        name: "Hyperledger Cluster"
-      brooklyn.parameters:
-      - name: hyperledger.node.count
-        description: |
-          The number of Hyperledger nodes to create in the cluster.
-        type: integer
-        default: 4
+        name: "Hyperledger Fabric"
 
-  - id: hyperledger-fabric-cluster-app
+  - id: hyperledger-fabric-cluster
     item:
       type: org.apache.brooklyn.entity.stock.BasicApplication
       brooklyn.children:
-        - type: hyperledger-cluster
-          name: Hyperledger Fabric Cluster
+        - type: hyperledger-vp-cluster
+          name: Validating Peer Cluster
 
         - type: hyperledger-services-host
           name: Membership Services and CLI Host
 
-  - id: docker-engine
+      brooklyn.parameters:
+      - name: hyperledger.vp.count
+        description: |
+          The number of Hyperledger Fabric validating peer nodes to create in the cluster.
+        type: integer
+        default: 4
+        constraints:
+          - required
+
+      brooklyn.config:
+        hyperledger.vp.count: 4
+
+  - id: hyperledger-docker-engine
     description: The engine for running Docker containers
     itemType: entity
     item:
@@ -317,7 +323,7 @@ brooklyn.catalog:
     item:
 
       name: Validating Peer Docker Host
-      type: docker-engine
+      type: hyperledger-docker-engine
 
       brooklyn.children:
       - type: hyperledger-validating-peer-node
@@ -328,7 +334,7 @@ brooklyn.catalog:
     item:
 
       name: Membership Services and CLI Docker Host
-      type: docker-engine
+      type: hyperledger-docker-engine
 
       brooklyn.children:
       - type: hyperledger-membersrvc-node
@@ -337,7 +343,7 @@ brooklyn.catalog:
       - type: hyperledger-cli-node
         id: my-hyperledger-cli-node
 
-  - id: hyperledger-cluster
+  - id: hyperledger-vp-cluster
     description: A cluster of Hyperledger Fabric validating peer nodes
     name: Hyperledger Fabric Cluster
     iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
@@ -345,7 +351,7 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.group.DynamicCluster
 
       brooklyn.config:
-        initialSize: $brooklyn:config("hyperledger.node.count")
+        initialSize: $brooklyn:config("hyperledger.vp.count")
 
       firstMemberSpec:
         $brooklyn:entitySpec:
@@ -360,10 +366,17 @@ brooklyn.catalog:
 
             hyperledger.peer.id: vp0
             hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
-            hyperledger.root.node.address: $brooklyn:component("root-node").attributeWhenReady("host.address")
+            hyperledger.root.node.address: $brooklyn:attributeWhenReady("host.address")
             hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
 
             launch.latch: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("service.isUp")
+
+          brooklyn.initializers:
+          - type: org.apache.brooklyn.core.sensor.StaticSensor
+            brooklyn.config:
+              name: my.root.node.address
+              targetType: java.lang.String
+              static.value: $brooklyn:attributeWhenReady("host.address")
 
       memberSpec:
         $brooklyn:entitySpec:
@@ -377,7 +390,7 @@ brooklyn.catalog:
 
             hyperledger.peer.id: $brooklyn:formatString("vp%s", $brooklyn:config("cluster.member.id"))
             hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
-            hyperledger.root.node.address: $brooklyn:component("root-node").attributeWhenReady("host.address")
+            hyperledger.root.node.address: $brooklyn:component("dynamic-regions-fabric-instance").attributeWhenReady("cluster.root.node.address.value")
             hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
 
             launch.latch: $brooklyn:component("root-node").attributeWhenReady("service.isUp")
@@ -390,3 +403,49 @@ brooklyn.catalog:
           enricher.aggregating.fromMembers: true
           enricher.sourceSensor: $brooklyn:sensor("host.address")
           enricher.targetSensor: $brooklyn:sensor("node.host.address.list")
+
+      - type: org.apache.brooklyn.enricher.stock.Aggregator
+        brooklyn.config:
+          enricher.sourceSensor: $brooklyn:sensor("my.root.node.address")
+          enricher.targetSensor: $brooklyn:sensor("my.root.node.address.list")
+          enricher.aggregating.fromMembers: true
+          enricher.aggregator.excludeBlank: true
+
+      - type: org.apache.brooklyn.enricher.stock.Joiner
+        brooklyn.config:
+          uniqueTag: tendermint-endpoint
+          enricher.sourceSensor: $brooklyn:sensor("my.root.node.address.list")
+          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address")
+          enricher.joiner.minimum: 1
+          enricher.joiner.maximum: 1
+          enricher.joiner.quote: false
+
+  - id: dynamic-regions-fabric
+    item:
+
+      name: Dynamic Regions Fabric
+      type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+      id: dynamic-regions-fabric-instance
+
+      memberSpec:
+        $brooklyn:entitySpec:
+          type: hyperledger-vp-cluster
+          name: Hyperledger Validating Peer Cluster
+
+      brooklyn.enrichers:
+      - type: org.apache.brooklyn.enricher.stock.Aggregator
+        brooklyn.config:
+          enricher.sourceSensor: $brooklyn:sensor("cluster.root.node.address")
+          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address.list")
+          enricher.aggregating.fromMembers: true
+          enricher.aggregator.excludeBlank: true
+
+      - type: org.apache.brooklyn.enricher.stock.Joiner
+        brooklyn.config:
+          uniqueTag: tendermint-endpoint
+          enricher.sourceSensor: $brooklyn:sensor("cluster.root.node.address.list")
+          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address.value")
+          # we want minimum 1 root node to be ready before publishing this sensor
+          enricher.joiner.minimum: 1
+          enricher.joiner.quote: false
+          enricher.joiner.separator: ","

--- a/catalog.bom
+++ b/catalog.bom
@@ -28,8 +28,26 @@ brooklyn.catalog:
         constraints:
           - required
 
+      - name: hyperledger.pbft.request.timeout
+        description: |
+          The number of seconds the PBFT plugin should wait when making requests.
+        type: integer
+        default: 120
+        constraints:
+          - required
+
+      - name: hyperledger.app.timeout
+        description: |
+          The number of seconds the demo app should wait between deploy, invoke, and query steps.
+        type: integer
+        default: 30
+        constraints:
+          - required
+
       brooklyn.config:
         hyperledger.peers.per.location: 4
+        hyperledger.pbft.request.timeout: 120
+        hyperledger.app.timeout: 30
 
   - id: hyperledger-fabric-cluster
     item:
@@ -92,7 +110,7 @@ brooklyn.catalog:
             --restart=unless-stopped \
             -i \
             -p 50051:50051 \
-            -e CORE_LOGGING_LEVEL=debug \
+            -e CORE_LOGGING_LEVEL=info \
             mikezaccardo/hyperledger-membersrvc:latest membersrvc >> ~/membersrvc.log 2>&1&
 
       checkRunning.command: |
@@ -116,6 +134,7 @@ brooklyn.catalog:
       shell.env:
         HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("host.address")
         HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
+        HYPERLEDGER_APP_TIMEOUT: $brooklyn:config("hyperledger.app.timeout")
         HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
 
       install.command: |
@@ -141,7 +160,7 @@ brooklyn.catalog:
                 cp /go/bin/core.yaml .; \
                 sed -i \"s/0.0.0.0/$HYPERLEDGER_ROOT_NODE_ADDRESS/g\" core.yaml; \
                 sed -i \"s/localhost/$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS/g\" core.yaml; \
-                sed -i \"s/30/180/g\" app.go; \
+                sed -i \"s/30/$HYPERLEDGER_APP_TIMEOUT/g\" app.go; \
                 curl -so infiniteloop.sh https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/infiniteloop.sh; \
                 chmod +x infiniteloop.sh; \
                 ./infiniteloop.sh" >> ~/cli.log 2>&1&
@@ -247,6 +266,7 @@ brooklyn.catalog:
         HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("host.address")
         HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
         HYPERLEDGER_NUM_NON_ROOT_PEERS: $brooklyn:component("my-hyperledger-fabric-cluster").attributeWhenReady("fabric.size")
+        HYPERLEDGER_PBFT_REQUEST_TIMEOUT: $brooklyn:config("hyperledger.pbft.request.timeout")
 
         SECRET_KEYS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("secret.keys")
 
@@ -290,7 +310,7 @@ brooklyn.catalog:
             -e CORE_PEER_ADDRESS=$HOST_ADDRESS:30303 \
             -e CORE_PEER_ADDRESSAUTODETECT=false \
             -e CORE_PEER_NETWORKID=dev \
-            -e CORE_LOGGING_LEVEL=debug \
+            -e CORE_LOGGING_LEVEL=info \
             -e CORE_SECURITY_ENABLED=true \
             -e CORE_SECURITY_PRIVACY=true \
             -e CORE_SECURITY_ENROLLID=test_$HYPERLEDGER_PEER_ID \
@@ -301,7 +321,7 @@ brooklyn.catalog:
             -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft \
             -e CORE_PBFT_GENERAL_MODE=classic \
             -e CORE_PBFT_GENERAL_N=$HYPERLEDGER_CLUSTER_TOTAL_SIZE \
-            -e CORE_PBFT_GENERAL_TIMEOUT_REQUEST=10s \
+            -e CORE_PBFT_GENERAL_TIMEOUT_REQUEST=${HYPERLEDGER_PBFT_REQUEST_TIMEOUT}s \
             mikezaccardo/hyperledger-peer:pbft peer node start >> ~/$HYPERLEDGER_PEER_ID.log 2>&1&
 
       checkRunning.command: |

--- a/catalog.bom
+++ b/catalog.bom
@@ -10,14 +10,26 @@ brooklyn.catalog:
 
   items:
   - id: hyperledger-fabric-template
-    description: A Hyperledger Fabric cluster of a membership services node, a CLI node, a root validating peer node, and cluster(s) of validating peer nodes
+    description: |
+        A Hyperledger Fabric cluster of a membership services node, a CLI node, a root
+        validating peer node, and cluster(s) of validating peer nodes
     name: "Hyperledger Fabric Cluster"
     iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
     itemType: template
     item:
       services:
-      - type: hyperledger-fabric-cluster
+      - type: hyperledger-fabric
         name: Hyperledger Fabric Cluster
+
+  - id: hyperledger-fabric
+    description: |
+      A Hyperledger Fabric cluster of a membership services node, a CLI node, a root
+      validating peer node, and cluster(s) of validating peer nodes
+    name: "Hyperledger Fabric Cluster"
+    iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
+    itemType: entity
+    item:
+      type: org.apache.brooklyn.entity.stock.BasicApplication
 
       brooklyn.parameters:
       - name: hyperledger.peers.per.location
@@ -27,7 +39,6 @@ brooklyn.catalog:
         default: 4
         constraints:
           - required
-
       - name: hyperledger.pbft.request.timeout
         description: |
           The number of seconds the PBFT plugin should wait when making requests.
@@ -35,7 +46,6 @@ brooklyn.catalog:
         default: 120
         constraints:
           - required
-
       - name: hyperledger.app.timeout
         description: |
           The number of seconds the demo app should wait between deploy, invoke, and query steps.
@@ -48,6 +58,10 @@ brooklyn.catalog:
         hyperledger.peers.per.location: 4
         hyperledger.pbft.request.timeout: 120
         hyperledger.app.timeout: 30
+
+      brooklyn.children:
+      - type: hyperledger-fabric-cluster
+        name: Hyperledger Fabric Cluster
 
   - id: hyperledger-fabric-cluster
     item:
@@ -401,61 +415,3 @@ brooklyn.catalog:
 
             secureContext:
               description: "The registered user"
-
-  - id: hyperledger-docker-engine
-    description: The engine for running Docker containers
-    itemType: entity
-    item:
-
-      name: Docker Engine (host)
-      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
-
-      install.command: |
-        sudo yum -y update
-        sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
-        sudo yum -y install docker-engine
-
-      post.install.command: |
-        # Configure Docker
-        sudo mkdir /etc/systemd/system/docker.service.d
-        echo "[Service]" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        echo "ExecStart=" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        echo 'ExecStart=/usr/bin/docker daemon -D --api-cors-header="*" -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock' | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        sudo systemctl daemon-reload
-
-      launch.command: |
-        sudo service docker start
-
-      stop.command: |
-        sudo service docker stop
-
-      checkRunning.command: |
-        sudo service docker status
-
-      provisioning.properties:
-        osFamily: centos
-        minRam: 4gb
-        installDevUrandom: true
-        required.ports:
-        # SSH setup
-        - 22
-        # Docker daemon
-        - 4243
-        # Hyperledger peer nodes
-        - 5000
-        - 30303
-        - 30304
-        - 31315
-        # Hyperledger member services node
-        - 50051
-        # Sequence service
-        - 9999
-
-      childStartMode: foreground_late

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,6 +1,6 @@
 brooklyn.catalog:
   id: brooklyn-hyperledger-fabric
-  version: 0.2.1
+  version: 0.3
 
   publish:
     description: |
@@ -9,97 +9,237 @@ brooklyn.catalog:
     icon_url: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
 
   items:
-
   - id: hyperledger-fabric-template
-    description: A Hyperledger Fabric cluster of validating peer nodes, a membership services node, and a CLI node
-    name: Hyperledger Fabric
+    description: A Hyperledger Fabric cluster of a membership services node, a CLI node, a root validating peer node, and cluster(s) of validating peer nodes
+    name: "Hyperledger Fabric Cluster"
     iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
     itemType: template
     item:
       services:
       - type: hyperledger-fabric-cluster
-        id: hyperledger-deployment
-        name: "Hyperledger Fabric"
-
-  - id: hyperledger-fabric-cluster
-    item:
-      type: org.apache.brooklyn.entity.stock.BasicApplication
-      brooklyn.children:
-        - type: hyperledger-vp-cluster
-          name: Validating Peer Cluster
-
-        - type: hyperledger-services-host
-          name: Membership Services and CLI Host
+        name: Hyperledger Fabric Cluster
 
       brooklyn.parameters:
-      - name: hyperledger.vp.count
+      - name: hyperledger.peers.per.location
         description: |
-          The number of Hyperledger Fabric validating peer nodes to create in the cluster.
+          The number of Hyperledger Fabric validating peer nodes to create in each location.
         type: integer
         default: 4
         constraints:
           - required
 
-      brooklyn.config:
-        hyperledger.vp.count: 4
+      - name: hyperledger.cluster.total.size
+        description: |
+          The total number of Hyperledger Fabric validating peer nodes across all locations (including root node).
+        type: integer
+        default: 5
+        constraints:
+          - required
 
-  - id: hyperledger-docker-engine
-    description: The engine for running Docker containers
+      brooklyn.config:
+        hyperledger.peers.per.location: 4
+        hyperledger.cluster.total.size: 5
+
+  - id: hyperledger-fabric-cluster
+    item:
+      name: Hyperledger Fabric Cluster
+      type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+
+      memberSpec:
+        $brooklyn:entitySpec:
+          type: hyperledger-vp-cluster
+          name: Hyperledger Validating Peer Cluster
+
+      brooklyn.children:
+      - type: hyperledger-services-host
+        name: Membership Services and CLI Host
+
+      - type: hyperledger-validating-peer-host
+        id: my-hyperledger-root-node
+        name: Root Validating Peer Host
+        brooklyn.config:
+          is.root.node: true
+          launch.latch: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("service.isUp")
+
+  - id: hyperledger-services-host
+    description: A Docker host running a Hyperledger Fabric Membership Services node, a CLI node, a sequence node, and the root validating peer node in separate containers
     itemType: entity
     item:
 
-      name: Docker Engine (host)
+      name: Membership Services and CLI Docker Host
+      type: hyperledger-docker-engine
+
+      brooklyn.children:
+      - type: hyperledger-membersrvc-node
+        id: my-hyperledger-membersrvc-node
+
+      - type: hyperledger-cli-node
+        id: my-hyperledger-cli-node
+
+      - type: hyperledger-sequence-node
+        id: my-hyperledger-sequence-node
+
+  - id: hyperledger-membersrvc-node
+    description: A Hyperledger Fabric membership services node
+    itemType: entity
+    item:
+
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      name: Membership Services Node
+
+      brooklyn.config:
+        launch.latch: $brooklyn:component("my-hyperledger-sequence-node").attributeWhenReady("service.isUp")
 
       install.command: |
-        sudo yum -y update
-        sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
-        sudo yum -y install docker-engine
-
-      post.install.command: |
-        # Configure Docker
-        sudo mkdir /etc/systemd/system/docker.service.d
-        echo "[Service]" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        echo "ExecStart=" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        echo 'ExecStart=/usr/bin/docker daemon -D --api-cors-header="*" -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock' | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
-        sudo systemctl daemon-reload
+        sudo docker pull mikezaccardo/hyperledger:latest
+        sudo docker tag mikezaccardo/hyperledger:latest hyperledger/fabric-baseimage:latest
+        sudo docker pull mikezaccardo/hyperledger-membersrvc:latest
 
       launch.command: |
-        sudo service docker start
-
-      stop.command: |
-        sudo service docker stop
+        nohup sudo docker run --name=membersrvc \
+            --restart=unless-stopped \
+            -i \
+            -p 50051:50051 \
+            -e CORE_LOGGING_LEVEL=debug \
+            mikezaccardo/hyperledger-membersrvc:latest membersrvc >> ~/membersrvc.log 2>&1&
 
       checkRunning.command: |
-        sudo service docker status
+        sudo docker inspect -f {{.State.Running}} membersrvc
 
-      provisioning.properties:
-        osFamily: centos
-        minRam: 4gb
-        installDevUrandom: true
-        required.ports:
-        # SSH setup
-        - 22
-        # Docker daemon
-        - 4243
-        # Hyperledger peer nodes
-        - 5000
-        - 30303
-        - 30304
-        - 31315
-        # Hyperledger member services node
-        - 50051
-        # Sequence service
-        - 9999
+      brooklyn.initializers:
+      - type: org.apache.brooklyn.core.sensor.StaticSensor
+        brooklyn.config:
+          name: secret.keys
+          targetType: java.lang.String
+          static.value: "MwYpmSRjupbT;5wgHK9qqYaPy;vQelbRvja7cJ;9LKqKH5peurL;Pqh90CEW5juZ;FfdvDkAdY81P;QiXJgHyV4t7A;twoKZouEyLyB;BxP7QNh778gI;wu3F1EwJWHvQ"
 
-      childStartMode: foreground_late
+  - id: hyperledger-cli-node
+    description: A Hyperledger Fabric CLI node
+    itemType: entity
+    item:
+
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      name: CLI Node
+
+      shell.env:
+        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("host.address")
+        HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
+        HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
+
+      install.command: |
+        sudo docker pull mikezaccardo/hyperledger:latest
+        sudo docker tag mikezaccardo/hyperledger:latest hyperledger/fabric-baseimage:latest
+        sudo docker pull mikezaccardo/hyperledger-peer:latest
+
+      launch.command:  |
+        nohup sudo docker run --name=cli \
+            -i \
+            -p 30303:30303 \
+            -p 30304:30304 \
+            -e CORE_VM_ENDPOINT=http://$HOST_ADDRESS:4243 \
+            -e CORE_PEER_ADDRESS=$HOST_ADDRESS:30303 \
+            -e CORE_PEER_ADDRESSAUTODETECT=false \
+            -e CORE_SECURITY_ENABLED=true \
+            -e CORE_SECURITY_PRIVACY=true \
+            -e HYPERLEDGER_ROOT_NODE_ADDRESS=$HYPERLEDGER_ROOT_NODE_ADDRESS \
+            -e HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS=$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS \
+            -e APP_HOME=/go/src/github.com/hyperledger/fabric/examples/chaincode/go/asset_management/app \
+            mikezaccardo/hyperledger-peer:latest /bin/bash -c \
+                "cd /go/src/github.com/hyperledger/fabric/examples/chaincode/go/asset_management/app; \
+                cp /go/bin/core.yaml .; \
+                sed -i \"s/0.0.0.0/$HYPERLEDGER_ROOT_NODE_ADDRESS/g\" core.yaml; \
+                sed -i \"s/localhost/$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS/g\" core.yaml; \
+                sed -i \"s/30/180/g\" app.go; \
+                curl -so infiniteloop.sh https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/infiniteloop.sh; \
+                chmod +x infiniteloop.sh; \
+                ./infiniteloop.sh" >> ~/cli.log 2>&1&
+
+      checkRunning.command: |
+        sudo docker inspect -f {{.State.Running}} cli
+
+  - id: hyperledger-sequence-node
+    description: A lightweight HTTP server that issues sequential integer values
+    itemType: entity
+    item:
+
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      name: Sequence Node
+      id: hyperledger-sequence
+
+      install.command: |
+        sudo yum -y install python
+
+      launch.command: |
+        cat > sequence.py <<"END"
+        from BaseHTTPServer import HTTPServer
+        from BaseHTTPServer import BaseHTTPRequestHandler
+
+        sequence = 0
+
+        class MyRequestHandler (BaseHTTPRequestHandler) :
+
+            def do_GET(self) :
+                global sequence
+
+                self.send_response(200)
+                self.send_header("Content-type:", "text/plain")
+                self.wfile.write("\n")
+
+                self.wfile.write(sequence)
+                sequence += 1
+
+        server = HTTPServer(("", 9999), MyRequestHandler)
+
+        server.serve_forever()
+        END
+
+        python sequence.py > sequence.out 2>&1 </dev/null & disown
+        echo $! > $PID_FILE
+
+      checkRunning.command: |
+        sudo netstat -nl | grep 9999
+
+      stop.command: |
+        sudo kill -9 $(cat $PID_FILE)
+
+  - id: hyperledger-vp-cluster
+    description: A cluster of Hyperledger Fabric validating peer nodes
+    name: Hyperledger Fabric Cluster
+    iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
+    item:
+      type: org.apache.brooklyn.entity.group.DynamicCluster
+
+      brooklyn.config:
+        initialSize: $brooklyn:config("hyperledger.peers.per.location")
+
+      memberSpec:
+        $brooklyn:entitySpec:
+          type: hyperledger-validating-peer-host
+          name: Validating Peer Docker Host
+
+          brooklyn.config:
+            is.root.node: false
+            launch.latch: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("service.isUp")
+
+      brooklyn.enrichers:
+      - type: org.apache.brooklyn.enricher.stock.Aggregator
+        brooklyn.config:
+          uniqueTag: node-address-aggregator
+          enricher.aggregator.excludeBlank: true
+          enricher.aggregating.fromMembers: true
+          enricher.sourceSensor: $brooklyn:sensor("host.address")
+          enricher.targetSensor: $brooklyn:sensor("node.host.address.list")
+
+  - id: hyperledger-validating-peer-host
+    description: A Docker host running a Hyperledger Fabric validating peer node in a container
+    itemType: entity
+    item:
+
+      name: Validating Peer Docker Host
+      type: hyperledger-docker-engine
+
+      brooklyn.children:
+      - type: hyperledger-validating-peer-node
 
   - id: hyperledger-validating-peer-node
     description: A Hyperledger Fabric validating peer node
@@ -109,21 +249,15 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
       name: Validating Peer Node
 
-      brooklyn.config:
-        secret.keys: "MwYpmSRjupbT;5wgHK9qqYaPy;vQelbRvja7cJ;9LKqKH5peurL"
-
-        launch.latch: $brooklyn:component("my-hyperledger-sequence-node").attributeWhenReady("service.isUp")
-
       shell.env:
         IS_ROOT_NODE: $brooklyn:config("is.root.node")
 
-        #CLUSTER_INDEX: $brooklyn:config("cluster.index")
-        #HYPERLEDGER_PEER_ID: $brooklyn:config("hyperledger.peer.id")
-        HYPERLEDGER_CLUSTER_SIZE: $brooklyn:config("hyperledger.cluster.size")
-        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:config("hyperledger.root.node.address")
-        HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:config("hyperledger.membersrvc.node.address")
+        HYPERLEDGER_CLUSTER_TOTAL_SIZE: $brooklyn:config("hyperledger.cluster.total.size")
+        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("host.address")
+        HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
 
-        SECRET_KEYS: $brooklyn:config("secret.keys")
+        SECRET_KEYS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("secret.keys")
+
         HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
         SEQ_HOST_ADDRESS: $brooklyn:component("my-hyperledger-sequence-node").attributeWhenReady("host.address")
 
@@ -139,6 +273,7 @@ brooklyn.catalog:
 
         CLUSTER_INDEX=$(curl http://$SEQ_HOST_ADDRESS:9999/)
         HYPERLEDGER_PEER_ID=vp$CLUSTER_INDEX
+        echo $HYPERLEDGER_PEER_ID > hyperledger.peer.id
 
         IFS=';' read -ra SECRET_KEYS_ARRAY <<< "$SECRET_KEYS"
         SECRET=${SECRET_KEYS_ARRAY[$CLUSTER_INDEX]}
@@ -171,13 +306,13 @@ brooklyn.catalog:
             -e CORE_PEER_PKI_TLSCA_PADDR=$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS:50051 \
             -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft \
             -e CORE_PBFT_GENERAL_MODE=classic \
-            -e CORE_PBFT_GENERAL_N=$HYPERLEDGER_CLUSTER_SIZE \
+            -e CORE_PBFT_GENERAL_N=$HYPERLEDGER_CLUSTER_TOTAL_SIZE \
             -e CORE_PBFT_GENERAL_TIMEOUT_REQUEST=10s \
             mikezaccardo/hyperledger-peer:pbft peer node start >> ~/$HYPERLEDGER_PEER_ID.log 2>&1&
 
       checkRunning.command: |
         # TODO actually query peer's status using `peer status` in container
-        sudo docker inspect -f {{.State.Running}} $HYPERLEDGER_PEER_ID
+        sudo docker inspect -f {{.State.Running}} $(cat hyperledger.peer.id)
 
       brooklyn.initializers:
       - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector
@@ -253,247 +388,60 @@ brooklyn.catalog:
             secureContext:
               description: "The registered user"
 
-  - id: hyperledger-membersrvc-node
-    description: A Hyperledger Fabric membership services node
+  - id: hyperledger-docker-engine
+    description: The engine for running Docker containers
     itemType: entity
     item:
 
+      name: Docker Engine (host)
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
-      name: Membership Services Node
 
       install.command: |
-        sudo docker pull mikezaccardo/hyperledger:latest
-        sudo docker tag mikezaccardo/hyperledger:latest hyperledger/fabric-baseimage:latest
-        sudo docker pull mikezaccardo/hyperledger-membersrvc:latest
+        sudo yum -y update
+        sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+        [dockerrepo]
+        name=Docker Repository
+        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+        enabled=1
+        gpgcheck=1
+        gpgkey=https://yum.dockerproject.org/gpg
+        EOF
+        sudo yum -y install docker-engine
+
+      post.install.command: |
+        # Configure Docker
+        sudo mkdir /etc/systemd/system/docker.service.d
+        echo "[Service]" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        echo "ExecStart=" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        echo 'ExecStart=/usr/bin/docker daemon -D --api-cors-header="*" -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock' | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        sudo systemctl daemon-reload
 
       launch.command: |
-        nohup sudo docker run --name=membersrvc \
-            --restart=unless-stopped \
-            -i \
-            -p 50051:50051 \
-            -e CORE_LOGGING_LEVEL=debug \
-            mikezaccardo/hyperledger-membersrvc:latest membersrvc >> ~/membersrvc.log 2>&1&
+        sudo service docker start
+
+      stop.command: |
+        sudo service docker stop
 
       checkRunning.command: |
-        sudo docker inspect -f {{.State.Running}} membersrvc
+        sudo service docker status
 
-  - id: hyperledger-sequence-node
-    description: A sequence node
-    itemType: entity
-    item:
+      provisioning.properties:
+        osFamily: centos
+        minRam: 4gb
+        installDevUrandom: true
+        required.ports:
+        # SSH setup
+        - 22
+        # Docker daemon
+        - 4243
+        # Hyperledger peer nodes
+        - 5000
+        - 30303
+        - 30304
+        - 31315
+        # Hyperledger member services node
+        - 50051
+        # Sequence service
+        - 9999
 
-      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
-      name: Sequence Node
-      id: hyperledger-sequence
-
-      install.command: |
-        sudo yum -y install python
-
-      launch.command: |
-        cat > sequence.py <<"END"
-        from BaseHTTPServer import HTTPServer
-        from BaseHTTPServer import BaseHTTPRequestHandler
-
-        sequence = 0
-
-        class MyRequestHandler (BaseHTTPRequestHandler) :
-
-            def do_GET(self) :
-                global sequence
-
-                self.send_response(200)
-                self.send_header("Content-type:", "text/plain")
-                self.wfile.write("\n")
-
-                self.wfile.write(sequence)
-                sequence += 1
-
-        server = HTTPServer(("", 9999), MyRequestHandler)
-
-        server.serve_forever()
-        END
-
-        python sequence.py >nohup.out 2>&1 </dev/null & disown
-        echo $! > $PID_FILE
-
-      checkRunning.command: |
-        sudo netstat -nl | grep 9999
-
-  - id: hyperledger-cli-node
-    description: A Hyperledger Fabric CLI node
-    itemType: entity
-    item:
-
-      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
-      name: CLI Node
-
-      shell.env:
-        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("dynamic-regions-fabric-instance").attributeWhenReady("cluster.root.node.address.value")
-        HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
-        HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
-
-      install.command: |
-        sudo docker pull mikezaccardo/hyperledger:latest
-        sudo docker tag mikezaccardo/hyperledger:latest hyperledger/fabric-baseimage:latest
-        sudo docker pull mikezaccardo/hyperledger-peer:latest
-
-      launch.command:  |
-        nohup sudo docker run --name=cli \
-            -i \
-            -p 30303:30303 \
-            -p 30304:30304 \
-            -e CORE_VM_ENDPOINT=http://$HOST_ADDRESS:4243 \
-            -e CORE_PEER_ADDRESS=$HOST_ADDRESS:30303 \
-            -e CORE_PEER_ADDRESSAUTODETECT=false \
-            -e CORE_SECURITY_ENABLED=true \
-            -e CORE_SECURITY_PRIVACY=true \
-            -e HYPERLEDGER_ROOT_NODE_ADDRESS=$HYPERLEDGER_ROOT_NODE_ADDRESS \
-            -e HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS=$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS \
-            -e APP_HOME=/go/src/github.com/hyperledger/fabric/examples/chaincode/go/asset_management/app \
-            mikezaccardo/hyperledger-peer:latest /bin/bash -c \
-                "cd /go/src/github.com/hyperledger/fabric/examples/chaincode/go/asset_management/app; \
-                cp /go/bin/core.yaml .; \
-                sed -i \"s/0.0.0.0/$HYPERLEDGER_ROOT_NODE_ADDRESS/g\" core.yaml; \
-                sed -i \"s/localhost/$HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS/g\" core.yaml; \
-                curl -so infiniteloop.sh https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/infiniteloop.sh; \
-                chmod +x infiniteloop.sh; \
-                ./infiniteloop.sh" >> ~/cli.log 2>&1&
-
-      checkRunning.command: |
-        sudo docker inspect -f {{.State.Running}} cli
-
-  - id: hyperledger-validating-peer-host
-    description: A Docker host running a Hyperledger Fabric validating peer node in a container
-    itemType: entity
-    item:
-
-      name: Validating Peer Docker Host
-      type: hyperledger-docker-engine
-
-      brooklyn.children:
-      - type: hyperledger-validating-peer-node
-
-  - id: hyperledger-services-host
-    description: A Docker host running a Hyperledger Fabric Membership Services node and a CLI node in separate containers
-    itemType: entity
-    item:
-
-      name: Membership Services and CLI Docker Host
-      type: hyperledger-docker-engine
-
-      brooklyn.children:
-      - type: hyperledger-membersrvc-node
-        id: my-hyperledger-membersrvc-node
-
-      - type: hyperledger-cli-node
-        id: my-hyperledger-cli-node
-
-      - type: hyperledger-sequence-node
-        id: my-hyperledger-sequence-node
-
-  - id: hyperledger-vp-cluster
-    description: A cluster of Hyperledger Fabric validating peer nodes
-    name: Hyperledger Fabric Cluster
-    iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
-    item:
-      type: org.apache.brooklyn.entity.group.DynamicCluster
-
-      brooklyn.config:
-        initialSize: $brooklyn:config("hyperledger.vp.count")
-
-      firstMemberSpec:
-        $brooklyn:entitySpec:
-          id: root-node
-          type: hyperledger-validating-peer-host
-          name: Validating Peer Docker Host (root)
-
-          brooklyn.config:
-            is.root.node: true
-
-            #cluster.index: $brooklyn:config("cluster.member.id")
-
-            #hyperledger.peer.id: vp0
-            hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
-            hyperledger.root.node.address: $brooklyn:attributeWhenReady("host.address")
-            hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
-
-            launch.latch: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("service.isUp")
-
-          brooklyn.initializers:
-          - type: org.apache.brooklyn.core.sensor.StaticSensor
-            brooklyn.config:
-              name: my.root.node.address
-              targetType: java.lang.String
-              static.value: $brooklyn:attributeWhenReady("host.address")
-
-      memberSpec:
-        $brooklyn:entitySpec:
-          type: hyperledger-validating-peer-host
-          name: Validating Peer Docker Host
-
-          brooklyn.config:
-            is.root.node: false
-
-            #cluster.index: $brooklyn:config("cluster.member.id")
-
-            #hyperledger.peer.id: $brooklyn:formatString("vp%s", $brooklyn:config("cluster.member.id"))
-            hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
-            hyperledger.root.node.address: $brooklyn:component("dynamic-regions-fabric-instance").attributeWhenReady("cluster.root.node.address.value")
-            hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
-
-            launch.latch: $brooklyn:component("root-node").attributeWhenReady("service.isUp")
-
-      brooklyn.enrichers:
-      - type: org.apache.brooklyn.enricher.stock.Aggregator
-        brooklyn.config:
-          uniqueTag: node-address-aggregator
-          enricher.aggregator.excludeBlank: true
-          enricher.aggregating.fromMembers: true
-          enricher.sourceSensor: $brooklyn:sensor("host.address")
-          enricher.targetSensor: $brooklyn:sensor("node.host.address.list")
-
-      - type: org.apache.brooklyn.enricher.stock.Aggregator
-        brooklyn.config:
-          enricher.sourceSensor: $brooklyn:sensor("my.root.node.address")
-          enricher.targetSensor: $brooklyn:sensor("my.root.node.address.list")
-          enricher.aggregating.fromMembers: true
-          enricher.aggregator.excludeBlank: true
-
-      - type: org.apache.brooklyn.enricher.stock.Joiner
-        brooklyn.config:
-          uniqueTag: tendermint-endpoint
-          enricher.sourceSensor: $brooklyn:sensor("my.root.node.address.list")
-          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address")
-          enricher.joiner.minimum: 1
-          enricher.joiner.maximum: 1
-          enricher.joiner.quote: false
-
-  - id: dynamic-regions-fabric
-    item:
-
-      name: Dynamic Regions Fabric
-      type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
-      id: dynamic-regions-fabric-instance
-
-      memberSpec:
-        $brooklyn:entitySpec:
-          type: hyperledger-vp-cluster
-          name: Hyperledger Validating Peer Cluster
-
-      brooklyn.enrichers:
-      - type: org.apache.brooklyn.enricher.stock.Aggregator
-        brooklyn.config:
-          enricher.sourceSensor: $brooklyn:sensor("cluster.root.node.address")
-          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address.list")
-          enricher.aggregating.fromMembers: true
-          enricher.aggregator.excludeBlank: true
-
-      - type: org.apache.brooklyn.enricher.stock.Joiner
-        brooklyn.config:
-          uniqueTag: tendermint-endpoint
-          enricher.sourceSensor: $brooklyn:sensor("cluster.root.node.address.list")
-          enricher.targetSensor: $brooklyn:sensor("cluster.root.node.address.value")
-          # we want minimum 1 root node to be ready before publishing this sensor
-          enricher.joiner.minimum: 1
-          enricher.joiner.quote: false
-          enricher.joiner.separator: ","
+      childStartMode: foreground_late

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,6 +1,6 @@
 brooklyn.catalog:
   id: brooklyn-hyperledger-fabric
-  version: 0.2.0
+  version: 0.2.1
 
   publish:
     description: |
@@ -96,6 +96,8 @@ brooklyn.catalog:
         - 31315
         # Hyperledger member services node
         - 50051
+        # Sequence service
+        - 9999
 
       childStartMode: foreground_late
 
@@ -110,19 +112,20 @@ brooklyn.catalog:
       brooklyn.config:
         secret.keys: "MwYpmSRjupbT;5wgHK9qqYaPy;vQelbRvja7cJ;9LKqKH5peurL"
 
+        launch.latch: $brooklyn:component("my-hyperledger-sequence-node").attributeWhenReady("service.isUp")
+
       shell.env:
         IS_ROOT_NODE: $brooklyn:config("is.root.node")
 
-        CLUSTER_INDEX: $brooklyn:config("cluster.index")
-
-        HYPERLEDGER_PEER_ID: $brooklyn:config("hyperledger.peer.id")
+        #CLUSTER_INDEX: $brooklyn:config("cluster.index")
+        #HYPERLEDGER_PEER_ID: $brooklyn:config("hyperledger.peer.id")
         HYPERLEDGER_CLUSTER_SIZE: $brooklyn:config("hyperledger.cluster.size")
         HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:config("hyperledger.root.node.address")
         HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:config("hyperledger.membersrvc.node.address")
 
         SECRET_KEYS: $brooklyn:config("secret.keys")
-
         HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
+        SEQ_HOST_ADDRESS: $brooklyn:component("my-hyperledger-sequence-node").attributeWhenReady("host.address")
 
       install.command: |
         sudo docker pull mikezaccardo/hyperledger:latest
@@ -133,6 +136,9 @@ brooklyn.catalog:
 
       launch.command: |
         echo $HOST_ADDRESS > host-address
+
+        CLUSTER_INDEX=$(curl http://$SEQ_HOST_ADDRESS:9999/)
+        HYPERLEDGER_PEER_ID=vp$CLUSTER_INDEX
 
         IFS=';' read -ra SECRET_KEYS_ARRAY <<< "$SECRET_KEYS"
         SECRET=${SECRET_KEYS_ARRAY[$CLUSTER_INDEX]}
@@ -271,6 +277,48 @@ brooklyn.catalog:
       checkRunning.command: |
         sudo docker inspect -f {{.State.Running}} membersrvc
 
+  - id: hyperledger-sequence-node
+    description: A sequence node
+    itemType: entity
+    item:
+
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      name: Sequence Node
+      id: hyperledger-sequence
+
+      install.command: |
+        sudo yum -y install python
+
+      launch.command: |
+        cat > sequence.py <<"END"
+        from BaseHTTPServer import HTTPServer
+        from BaseHTTPServer import BaseHTTPRequestHandler
+
+        sequence = 0
+
+        class MyRequestHandler (BaseHTTPRequestHandler) :
+
+            def do_GET(self) :
+                global sequence
+
+                self.send_response(200)
+                self.send_header("Content-type:", "text/plain")
+                self.wfile.write("\n")
+
+                self.wfile.write(sequence)
+                sequence += 1
+
+        server = HTTPServer(("", 9999), MyRequestHandler)
+
+        server.serve_forever()
+        END
+
+        python sequence.py >nohup.out 2>&1 </dev/null & disown
+        echo $! > $PID_FILE
+
+      checkRunning.command: |
+        sudo netstat -nl | grep 9999
+
   - id: hyperledger-cli-node
     description: A Hyperledger Fabric CLI node
     itemType: entity
@@ -279,11 +327,8 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
       name: CLI Node
 
-      brooklyn.config:
-        launch.latch: $brooklyn:component("root-node").attributeWhenReady("service.isUp")
-
       shell.env:
-        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("root-node").attributeWhenReady("host.address")
+        HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("dynamic-regions-fabric-instance").attributeWhenReady("cluster.root.node.address.value")
         HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
         HOST_ADDRESS: $brooklyn:attributeWhenReady("host.address")
 
@@ -343,6 +388,9 @@ brooklyn.catalog:
       - type: hyperledger-cli-node
         id: my-hyperledger-cli-node
 
+      - type: hyperledger-sequence-node
+        id: my-hyperledger-sequence-node
+
   - id: hyperledger-vp-cluster
     description: A cluster of Hyperledger Fabric validating peer nodes
     name: Hyperledger Fabric Cluster
@@ -362,9 +410,9 @@ brooklyn.catalog:
           brooklyn.config:
             is.root.node: true
 
-            cluster.index: $brooklyn:config("cluster.member.id")
+            #cluster.index: $brooklyn:config("cluster.member.id")
 
-            hyperledger.peer.id: vp0
+            #hyperledger.peer.id: vp0
             hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
             hyperledger.root.node.address: $brooklyn:attributeWhenReady("host.address")
             hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
@@ -386,9 +434,9 @@ brooklyn.catalog:
           brooklyn.config:
             is.root.node: false
 
-            cluster.index: $brooklyn:config("cluster.member.id")
+            #cluster.index: $brooklyn:config("cluster.member.id")
 
-            hyperledger.peer.id: $brooklyn:formatString("vp%s", $brooklyn:config("cluster.member.id"))
+            #hyperledger.peer.id: $brooklyn:formatString("vp%s", $brooklyn:config("cluster.member.id"))
             hyperledger.cluster.size: $brooklyn:config("cluster.initial.size")
             hyperledger.root.node.address: $brooklyn:component("dynamic-regions-fabric-instance").attributeWhenReady("cluster.root.node.address.value")
             hyperledger.membersrvc.node.address: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,6 @@
 brooklyn.catalog:
-  version: 0.1.0_SNAPSHOT
+  id: brooklyn-hyperledger-fabric
+  version: 0.1.1_SNAPSHOT
 
   publish:
     description: |
@@ -8,6 +9,34 @@ brooklyn.catalog:
     icon_url: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
 
   items:
+
+  - id: hyperledger-fabric-cluster
+    description: A Hyperledger Fabric cluster of validating peer nodes, a membership services node, and a CLI node
+    name: Hyperledger Fabric Cluster
+    iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
+    itemType: template
+    item:
+      services:
+      - type: hyperledger-fabric-cluster-app
+        id: hyperledger-deployment
+        name: "Hyperledger Cluster"
+      brooklyn.parameters:
+      - name: hyperledger.node.count
+        description: |
+          The number of Hyperledger nodes to create in the cluster.
+        type: integer
+        default: 4
+
+  - id: hyperledger-fabric-cluster-app
+    item:
+      type: org.apache.brooklyn.entity.stock.BasicApplication
+      brooklyn.children:
+        - type: hyperledger-cluster
+          name: Hyperledger Fabric Cluster
+
+        - type: hyperledger-services-host
+          name: Membership Services and CLI Host
+
   - id: docker-engine
     description: The engine for running Docker containers
     itemType: entity
@@ -316,7 +345,7 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.group.DynamicCluster
 
       brooklyn.config:
-        initialSize: 4
+        initialSize: $brooklyn:config("hyperledger.node.count")
 
       firstMemberSpec:
         $brooklyn:entitySpec:
@@ -361,16 +390,3 @@ brooklyn.catalog:
           enricher.aggregating.fromMembers: true
           enricher.sourceSensor: $brooklyn:sensor("host.address")
           enricher.targetSensor: $brooklyn:sensor("node.host.address.list")
-
-  - id: hyperledger-fabric-cluster
-    description: A Hyperledger Fabric cluster of validating peer nodes, a membership services node, and a CLI node
-    name: Hyperledger Fabric Cluster
-    iconUrl: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
-    itemType: template
-    item:
-      services:
-      - type: hyperledger-cluster
-        name: Hyperledger Fabric Cluster
-
-      - type: hyperledger-services-host
-        name: Membership Services and CLI Host

--- a/catalog.bom
+++ b/catalog.bom
@@ -28,22 +28,14 @@ brooklyn.catalog:
         constraints:
           - required
 
-      - name: hyperledger.cluster.total.size
-        description: |
-          The total number of Hyperledger Fabric validating peer nodes across all locations (including root node).
-        type: integer
-        default: 5
-        constraints:
-          - required
-
       brooklyn.config:
         hyperledger.peers.per.location: 4
-        hyperledger.cluster.total.size: 5
 
   - id: hyperledger-fabric-cluster
     item:
       name: Hyperledger Fabric Cluster
       type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+      id: my-hyperledger-fabric-cluster
 
       memberSpec:
         $brooklyn:entitySpec:
@@ -252,9 +244,9 @@ brooklyn.catalog:
       shell.env:
         IS_ROOT_NODE: $brooklyn:config("is.root.node")
 
-        HYPERLEDGER_CLUSTER_TOTAL_SIZE: $brooklyn:config("hyperledger.cluster.total.size")
         HYPERLEDGER_ROOT_NODE_ADDRESS: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("host.address")
         HYPERLEDGER_MEMBERSRVC_NODE_ADDRESS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("host.address")
+        HYPERLEDGER_NUM_NON_ROOT_PEERS: $brooklyn:component("my-hyperledger-fabric-cluster").attributeWhenReady("fabric.size")
 
         SECRET_KEYS: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("secret.keys")
 
@@ -277,6 +269,8 @@ brooklyn.catalog:
 
         IFS=';' read -ra SECRET_KEYS_ARRAY <<< "$SECRET_KEYS"
         SECRET=${SECRET_KEYS_ARRAY[$CLUSTER_INDEX]}
+
+        HYPERLEDGER_CLUSTER_TOTAL_SIZE=$(($HYPERLEDGER_NUM_NON_ROOT_PEERS + 1))
 
         # Additional arguments for peer nodes
         if [ $IS_ROOT_NODE == "false" ]; then

--- a/catalog.bom
+++ b/catalog.bom
@@ -40,7 +40,7 @@ brooklyn.catalog:
         description: |
           The number of seconds the demo app should wait between deploy, invoke, and query steps.
         type: integer
-        default: 30
+        default: 180
         constraints:
           - required
 

--- a/docker.bom
+++ b/docker.bom
@@ -1,0 +1,68 @@
+brooklyn.catalog:
+  id: brooklyn-hyperledger-fabric-docker
+  version: 0.5
+
+  publish:
+    description: |
+      Entities for running the Hyperledger Fabric project in Apache Brooklyn.
+    license_code: Apache-2.0
+    icon_url: https://raw.githubusercontent.com/cloudsoft/brooklyn-hyperledger/master/hyperledger-fabric-icon.png
+
+  items:
+  - id: hyperledger-docker-engine
+    description: The engine for running Docker containers
+    itemType: entity
+    item:
+
+      name: Docker Engine (host)
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+
+      install.command: |
+        sudo yum -y update
+        sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+        [dockerrepo]
+        name=Docker Repository
+        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+        enabled=1
+        gpgcheck=1
+        gpgkey=https://yum.dockerproject.org/gpg
+        EOF
+        sudo yum -y install docker-engine
+
+      post.install.command: |
+        # Configure Docker
+        sudo mkdir /etc/systemd/system/docker.service.d
+        echo "[Service]" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        echo "ExecStart=" | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        echo 'ExecStart=/usr/bin/docker daemon -D --api-cors-header="*" -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock' | sudo tee --append /etc/systemd/system/docker.service.d/docker.conf > /dev/null
+        sudo systemctl daemon-reload
+
+      launch.command: |
+        sudo service docker start
+
+      stop.command: |
+        sudo service docker stop
+
+      checkRunning.command: |
+        sudo service docker status
+
+      provisioning.properties:
+        osFamily: centos
+        minRam: 4gb
+        installDevUrandom: true
+        required.ports:
+        # SSH setup
+        - 22
+        # Docker daemon
+        - 4243
+        # Hyperledger peer nodes
+        - 5000
+        - 30303
+        - 30304
+        - 31315
+        # Hyperledger member services node
+        - 50051
+        # Sequence service
+        - 9999
+
+      childStartMode: foreground_late


### PR DESCRIPTION
Restructures the blueprint into:
- CLI, membership services, sequence node on a host
- Root VP node on a host
- Non-root VP nodes in a Brooklyn Fabric, one cluster per location, each node on a separate host

Thanks to @googlielmo for the initial Brooklyn Fabric work and for the sequence node!
