### PR TITLE
Remove multi-cluster template

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Use [this guide](http://docs.cloudsoft.io/locations/first-location/index.html) t
 ### Step 3a: Deploy a Hyperledger Fabric Single-cluster
 
 * Browse to the AMP user interface (address listed in the installation guide)
-* Scroll through the "Quick launch" tile and click "Hyperledger Fabric Single-cluster"
+* Scroll through the "Quick launch" tile and click "Hyperledger Fabric Cluster"
 * Optionally provide a name
 * Provide the location that you created (or `byon-cluster` by default, if using Vagrant)
 * Increase the number of peers if desired

--- a/catalog/hyperledger/multi-cluster.bom
+++ b/catalog/hyperledger/multi-cluster.bom
@@ -8,19 +8,6 @@ brooklyn.catalog:
     icon_url: classpath://io.brooklyn.hyperledger:icon/hyperledger-fabric.png
 
   items:
-  - id: hyperledger-fabric-multi-cluster-template
-    description: |
-      A Hyperledger Fabric cluster of a membership services node, a CLI node, a root
-      validating peer node, and cluster(s) of validating peer nodes running in multiple
-      locations.
-    name: "Hyperledger Fabric Multi-cluster"
-    iconUrl: classpath://io.brooklyn.hyperledger:icon/hyperledger-fabric.png
-    itemType: template
-    item:
-      services:
-      - type: hyperledger-fabric-multi-cluster-application
-        name: "Hyperledger Fabric Multi-cluster"
-
   - id: hyperledger-fabric-multi-cluster-application
     description: |
       A Hyperledger Fabric cluster of a membership services node, a CLI node, a root

--- a/catalog/hyperledger/single-cluster.bom
+++ b/catalog/hyperledger/single-cluster.bom
@@ -13,13 +13,13 @@ brooklyn.catalog:
       A Hyperledger Fabric cluster of a membership services node, a CLI node, a root
       validating peer node, and a single cluster of validating peer nodes running in a
       single location.
-    name: "Hyperledger Fabric Single-cluster"
+    name: "Hyperledger Fabric Cluster"
     iconUrl: classpath://io.brooklyn.hyperledger:icon/hyperledger-fabric.png
     itemType: template
     item:
       services:
       - type: hyperledger-fabric-single-cluster-application
-        name: "Hyperledger Fabric Single-cluster"
+        name: "Hyperledger Fabric Cluster"
 
   - id: hyperledger-fabric-single-cluster-application
     description: |
@@ -29,7 +29,7 @@ brooklyn.catalog:
     publish:
       license_code: Apache-2.0
       overview: README.md
-    name: "Hyperledger Fabric Single-cluster"
+    name: "Hyperledger Fabric Cluster"
     iconUrl: classpath://io.brooklyn.hyperledger:icon/hyperledger-fabric.png
     itemType: entity
     item:
@@ -67,11 +67,11 @@ brooklyn.catalog:
 
       brooklyn.children:
       - type: hyperledger-fabric-single-cluster
-        name: "Hyperledger Fabric Single-cluster"
+        name: "Hyperledger Fabric Cluster"
 
   - id: hyperledger-fabric-single-cluster
     item:
-      name: "Hyperledger Fabric Single-cluster"
+      name: "Hyperledger Fabric Cluster"
       type: org.apache.brooklyn.entity.stock.BasicApplication
 
       brooklyn.children:

--- a/examples/hyperledger-multi-cluster.yaml
+++ b/examples/hyperledger-multi-cluster.yaml
@@ -5,7 +5,7 @@ locations:
   - <add-location-here>
   - <add-location-here>
 services:
-  - type: 'hyperledger-fabric-multi-cluster-template'
+  - type: 'hyperledger-fabric-multi-cluster-application'
     brooklyn.config:
       hyperledger.peers.per.location: 2
       hyperledger.pbft.request.timeout: 120

--- a/examples/hyperledger-single-cluster.yaml
+++ b/examples/hyperledger-single-cluster.yaml
@@ -1,6 +1,6 @@
 location: <add-location-here>
 services:
-  - type: 'hyperledger-fabric-single-cluster-template'
+  - type: 'hyperledger-fabric-single-cluster-application'
     brooklyn.config:
       hyperledger.peers.per.location: 4
       hyperledger.pbft.request.timeout: 120


### PR DESCRIPTION
* Removes the template for multi-cluster so it does not appear in the Brooklyn/AMP quick launch menu
* Multi-cluster can still be deployed via YAML file as intended