### PR TITLE
Update packaging config to allow installation via brooklyn.libraries

### DIFF
--- a/catalog/catalog.bom
+++ b/catalog/catalog.bom
@@ -1,0 +1,3 @@
+brooklyn.catalog:
+  items:
+    - classpath://hyperledger/catalog.bom

--- a/catalog/hyperledger/catalog.bom
+++ b/catalog/hyperledger/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
   items:
-    - classpath://io.brooklyn.hyperledger:hyperledger/common.bom
-    - classpath://io.brooklyn.hyperledger:hyperledger/single-cluster.bom
-    - classpath://io.brooklyn.hyperledger:hyperledger/multi-cluster.bom
+    - classpath://hyperledger/common.bom
+    - classpath://hyperledger/single-cluster.bom
+    - classpath://hyperledger/multi-cluster.bom

--- a/hyperledger.bom
+++ b/hyperledger.bom
@@ -1,3 +1,0 @@
-brooklyn.catalog:
-  items:
-    - classpath://io.brooklyn.hyperledger:hyperledger/catalog.bom


### PR DESCRIPTION
To install a bundle via a bom file and brooklyn.libraries, you need to have:

- a valid OSGi bundle (was already there)
- a `catalog.bom` at the root of the bundle, which this PR adds