### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/catalog/hyperledger/multi-cluster.bom
+++ b/catalog/hyperledger/multi-cluster.bom
@@ -76,7 +76,7 @@ brooklyn.catalog:
         name: "Root Validating Peer Host"
         brooklyn.config:
           is.root.node: true
-          launch.latch: $brooklyn:component("my-hyperledger-membersrvc-node-multi").attributeWhenReady("service.isUp")
+          latch.launch: $brooklyn:component("my-hyperledger-membersrvc-node-multi").attributeWhenReady("service.isUp")
 
   - id: hyperledger-services-host-multi
     description: |
@@ -103,7 +103,7 @@ brooklyn.catalog:
       name: Membership Services Node
 
       brooklyn.config:
-        launch.latch: $brooklyn:component("my-hyperledger-sequence-node-multi").attributeWhenReady("service.isUp")
+        latch.launch: $brooklyn:component("my-hyperledger-sequence-node-multi").attributeWhenReady("service.isUp")
 
       install.command: |
         sudo docker pull hyperledger/fabric-membersrvc:x86_64-0.6.1-preview
@@ -280,7 +280,7 @@ brooklyn.catalog:
 
           brooklyn.config:
             is.root.node: false
-            launch.latch: $brooklyn:component("my-hyperledger-root-node-multi").attributeWhenReady("service.isUp")
+            latch.launch: $brooklyn:component("my-hyperledger-root-node-multi").attributeWhenReady("service.isUp")
 
       brooklyn.enrichers:
       - type: org.apache.brooklyn.enricher.stock.Aggregator

--- a/catalog/hyperledger/single-cluster.bom
+++ b/catalog/hyperledger/single-cluster.bom
@@ -209,7 +209,7 @@ brooklyn.catalog:
 
           brooklyn.config:
             is.root.node: true
-            launch.latch: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("service.isUp")
+            latch.launch: $brooklyn:component("my-hyperledger-membersrvc-node").attributeWhenReady("service.isUp")
 
       memberSpec:
         $brooklyn:entitySpec:
@@ -218,7 +218,7 @@ brooklyn.catalog:
 
           brooklyn.config:
             is.root.node: false
-            launch.latch: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("service.isUp")
+            latch.launch: $brooklyn:component("my-hyperledger-root-node").attributeWhenReady("service.isUp")
 
       brooklyn.enrichers:
       - type: org.apache.brooklyn.enricher.stock.Aggregator


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names.